### PR TITLE
Fixed mapping and ignore panorama predictions

### DIFF
--- a/evaluate.py
+++ b/evaluate.py
@@ -85,7 +85,7 @@ def main():
     for i, k in enumerate(predictions[:, 1:]):
         missing_elem_in_database = np.in1d(k, database_keys, invert = True)
         if missing_elem_in_database.all():
-            print(i, missing_elem_in_database)
+
             print("Some of your predictions are not in the database for the selected task {}".format(k[missing_elem_in_database]))
             print("This is probably because they are panorama images. They will be ignored in evaluation")
 

--- a/mapillary_sls/utils/eval.py
+++ b/mapillary_sls/utils/eval.py
@@ -18,21 +18,21 @@ def rank_embeddings(qvecs, dbvecs):
 
 def eval(query_keys, positive_keys, predictions, ks = [1, 5, 10, 20]):
 	
-	# ensure that the positive and predictions are for the same elements
-	pred_queries = predictions[:,0:1]
-	pred2gt = [np.where(query_keys == pred_key)[0][0] for pred_key in pred_queries]
+    # ensure that the positive and predictions are for the same elements
+    pred_queries = predictions[:,0:1]
+    pred2gt = [np.where(pred_queries == key)[0][0] for key in query_keys]
 
-	# change order to fit with ground truth
-	predictions = predictions[pred2gt,1:]
+    # change order to fit with ground truth
+    predictions = predictions[pred2gt,1:]
 
-	recall_at_k = recall(predictions, positive_keys, ks)
+    recall_at_k = recall(predictions, positive_keys, ks)
 
-	metrics = {}
-	for i, k in enumerate(ks):
-		metrics['recall@{}'.format(k)] = recall_at_k[i]
-		metrics['map@{}'.format(k)] = mapk(predictions, positive_keys, k)
+    metrics = {}
+    for i, k in enumerate(ks):
+        metrics['recall@{}'.format(k)] = recall_at_k[i]
+        metrics['map@{}'.format(k)] = mapk(predictions, positive_keys, k)
 
-	return metrics
+    return metrics
 
 def recall(ranks, pidx, ks):
 	


### PR DESCRIPTION
Hi manu

I checked some things:
1) The mapping does now work as supposed, thus the ordering of the cities can vary and we still get the same results

2) Instead of an assertion when a prediction is not in the database image (which might be the case because of panorama images), I just ignore and move these predictions to the end of the list. 